### PR TITLE
dts: sun60iw2p1: set sunxi-drm to prefer-fhd

### DIFF
--- a/configs/linux-5.15/sun60iw2p1.dtsi
+++ b/configs/linux-5.15/sun60iw2p1.dtsi
@@ -3720,6 +3720,8 @@
 		sunxi_drm: sunxi-drm {
 			compatible = "allwinner,sunxi-drm";
 			fb_base = <0>;
+			quirk-prefer-fhd;
+			quirk-prefer-large-60;
 			status = "okay";
 		};
 


### PR DESCRIPTION
For better out-of-the-box performance.
And the fix time for the rendering error
under 4K agreed by allwnner is too far away.(Mid September)