### PR TITLE
drivers: vin: imx214: enable streaming for 4K mode

### DIFF
--- a/drivers/vin/modules/sensor/imx214.c
+++ b/drivers/vin/modules/sensor/imx214.c
@@ -309,6 +309,8 @@ static struct regval_list sensor_4k_videos[] = {
 	{0x4177, 0x3C},
 	{0xAE20, 0x04},
 	{0xAE21, 0x5C},
+	{0x0138, 0x01},
+	{0x0100, 0x01},
 };
 
 static struct regval_list sensor_1080p_regs[] = {


### PR DESCRIPTION
To fix the issue of not being able to capture pictures in 4K mode